### PR TITLE
Fix broken nav links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,15 +32,15 @@ image_alt = "Playful dog getting ready"
 
 [[menu.main]]
 	name = "The benefits of Data Science"
-	url = "benefits"
+	url = "/benefits/"
     weight = 2
 
 [[menu.main]]
     name = "About"
-    url = "team"
+    url = "/team/"
     weight = 3
 
 [[menu.main]]
     name = "Sign up"
-    url = "register"
+    url = "/register/"
     weight = 4


### PR DESCRIPTION
Nav links are currently broken, this PR fixes the links in the config

Repro:
- Go to "Benefits of data science page" from menu
- Go to "About" from menu

URL is https://nightingalehq.ai/benefits/team instead of https://nightingalehq.ai/team which results in a 404. 